### PR TITLE
Veridise audit fixes

### DIFF
--- a/aleo-programs/arc_0038/arc_0038.aleo
+++ b/aleo-programs/arc_0038/arc_0038.aleo
@@ -343,14 +343,13 @@ finalize bond_all:
     get.or_use credits.aleo/bonded[aleo1j0zju7f0fpgv98gulyywtkxk6jca99l6425uqhnd5kccu4jc2grstjx0mt] r5 into r6;
     get total_balance[0u8] into r7;
     get pending_deposits[0u8] into r8;
-    add r8 r7 into r9;
-    sub r9 r6.microcredits into r10;
-    set r10 into pending_deposits[0u8];
+    sub r2 r3 into r9;
+    set r9 into pending_deposits[0u8];
     set r6.microcredits into total_balance[0u8];
 // Set validator, call will fail if next validator is not set
-    get validator[1u8] into r11;
-    assert.eq r1 r11;
-    set r11 into validator[0u8];
+    get validator[1u8] into r10;
+    assert.eq r1 r10;
+    set r10 into validator[0u8];
     remove validator[1u8];
 
 
@@ -372,15 +371,14 @@ finalize bond_deposits:
     gte r3 r4 into r5;
     assert.eq r5 true;
     get total_balance[0u8] into r6;
-    get pending_deposits[0u8] into r7;
-    sub r7 r1 into r8;
-    set r8 into pending_deposits[0u8];
-    add r6 r1 into r9;
-    set r9 into total_balance[0u8];
-    contains validator[1u8] into r10;
-    assert.eq r10 false;
-    get validator[0u8] into r11;
-    assert.eq r11 r2;
+    sub r3 r4 into r7;
+    set r7 into pending_deposits[0u8];
+    add r6 r1 into r8;
+    set r8 into total_balance[0u8];
+    contains validator[1u8] into r9;
+    assert.eq r9 false;
+    get validator[0u8] into r10;
+    assert.eq r10 r2;
 
 
 // Distribute shares for new commission

--- a/aleo-programs/arc_0038/arc_0038.aleo
+++ b/aleo-programs/arc_0038/arc_0038.aleo
@@ -601,34 +601,30 @@ finalize withdraw_public:
     gte r66 r67 into r68;
     assert.eq r68 true;
 // Update withdrawals mappings
-    div block.height 1000u32 into r69;
-    mul r69 1000u32 into r70;
-    add r70 1000u32 into r71;
-    ternary r7 r71 r5 into r72;
-    set r72 into current_batch_height[0u8];
-    cast r2 r72 into r73 as withdrawal_state;
-    set r73 into withdrawals[r3];
+    add block.height 1_000u32 into r69;
+    ternary r7 r69 r5 into r70;
+    set r70 into current_batch_height[0u8];
+    cast r2 r70 into r71 as withdrawal_state;
+    set r71 into withdrawals[r3];
 // Update pending withdrawal
-    add r14 r2 into r74;
-    set r74 into pending_withdrawal[0u8];
+    add r14 r2 into r72;
+    set r72 into pending_withdrawal[0u8];
 // Update total balance
-    sub r56 r2 into r75;
-    set r75 into total_balance[0u8];
+    sub r56 r2 into r73;
+    set r73 into total_balance[0u8];
 // Update total shares
-    sub r55 r1 into r76;
-    set r76 into total_shares[0u8];
+    sub r55 r1 into r74;
+    set r74 into total_shares[0u8];
 // Update delegator_shares mapping
-    get delegator_shares[r3] into r77;
-    sub r77 r1 into r78;
-    set r78 into delegator_shares[r3];
+    get delegator_shares[r3] into r75;
+    sub r75 r1 into r76;
+    set r76 into delegator_shares[r3];
 
 
 function get_new_batch_height_test:
     input r0 as u32.private;
-    div r0 1000u32 into r1;
-    mul r1 1000u32 into r2;
-    add r2 1000u32 into r3;
-    output r3 as u32.private;
+    add r0 1_000u32 into r1;
+    output r1 as u32.private;
 
 
 function create_withdraw_claim:

--- a/aleo-programs/arc_0038/arc_0038.aleo
+++ b/aleo-programs/arc_0038/arc_0038.aleo
@@ -3,7 +3,7 @@ program arc_0038.aleo;
 
 // Constants
 // ADMIN: address = aleo1kf3dgrz9lqyklz8kqfy0hpxxyt78qfuzshuhccl02a5x43x6nqpsaapqru - the admin address is the address of the contract creator
-// CORE_PROTOCOL: address = aleo1j0zju7f0fpgv98gulyywtkxk6jca99l6425uqhnd5kccu4jc2grstjx0mt - the address of this program
+// CORE_PROTOCOL: address = arc_0038.aleo - the address of this program
 // SHARES_TO_MICROCREDITS: u64 = 1_000u64;
 // PRECISION_UNSIGNED: u128 = 1_000u128;
 // MAX_COMMISSION_RATE: u128 = 500u128;
@@ -104,7 +104,7 @@ function initialize:
     assert.eq r2 true;
     lte r0 500u128 into r3;
     assert.eq r3 true;
-    assert.neq r1 aleo1j0zju7f0fpgv98gulyywtkxk6jca99l6425uqhnd5kccu4jc2grstjx0mt;
+    assert.neq r1 arc_0038.aleo;
     async initialize r0 r1 into r4;
     output r4 as arc_0038.aleo/initialize.future;
 
@@ -128,8 +128,8 @@ function initial_deposit:
     input r0 as u64.public;
     input r1 as address.public;
     assert.eq self.caller aleo1kf3dgrz9lqyklz8kqfy0hpxxyt78qfuzshuhccl02a5x43x6nqpsaapqru;
-    call credits.aleo/transfer_public_as_signer aleo1j0zju7f0fpgv98gulyywtkxk6jca99l6425uqhnd5kccu4jc2grstjx0mt r0 into r2;
-    call credits.aleo/bond_public r1 aleo1j0zju7f0fpgv98gulyywtkxk6jca99l6425uqhnd5kccu4jc2grstjx0mt r0 into r3;
+    call credits.aleo/transfer_public_as_signer arc_0038.aleo r0 into r2;
+    call credits.aleo/bond_public r1 arc_0038.aleo r0 into r3;
     async initial_deposit r2 r3 r0 r1 into r4;
     output r4 as arc_0038.aleo/initial_deposit.future;
 
@@ -194,8 +194,8 @@ function set_commission_percent:
 finalize set_commission_percent:
     input r0 as u128.public;
 // Make sure all commission is claimed before changing the rate
-    cast aleo1j0zju7f0fpgv98gulyywtkxk6jca99l6425uqhnd5kccu4jc2grstjx0mt 0u64 into r1 as bond_state;
-    get.or_use credits.aleo/bonded[aleo1j0zju7f0fpgv98gulyywtkxk6jca99l6425uqhnd5kccu4jc2grstjx0mt] r1 into r2;
+    cast arc_0038.aleo 0u64 into r1 as bond_state;
+    get.or_use credits.aleo/bonded[arc_0038.aleo] r1 into r2;
     get total_balance[0u8] into r3;
     get total_shares[0u8] into r4;
     gt r2.microcredits r3 into r5;
@@ -237,7 +237,7 @@ finalize set_commission_percent:
 function set_next_validator:
     input r0 as address.public;
     assert.eq self.caller aleo1kf3dgrz9lqyklz8kqfy0hpxxyt78qfuzshuhccl02a5x43x6nqpsaapqru;
-    assert.neq r0 aleo1j0zju7f0fpgv98gulyywtkxk6jca99l6425uqhnd5kccu4jc2grstjx0mt;
+    assert.neq r0 arc_0038.aleo;
     async set_next_validator r0 into r1;
     output r1 as arc_0038.aleo/set_next_validator.future;
 
@@ -257,13 +257,13 @@ finalize unbond_all:
     await r0;
     contains validator[1u8] into r1;
     assert.eq r1 true;
-    cast aleo1j0zju7f0fpgv98gulyywtkxk6jca99l6425uqhnd5kccu4jc2grstjx0mt 0u64 into r2 as bond_state;
-    get.or_use credits.aleo/bonded[aleo1j0zju7f0fpgv98gulyywtkxk6jca99l6425uqhnd5kccu4jc2grstjx0mt] r2 into r3;
+    cast arc_0038.aleo 0u64 into r2 as bond_state;
+    get.or_use credits.aleo/bonded[arc_0038.aleo] r2 into r3;
 // Assert that the pool was fully unbonded
     assert.eq r3.microcredits 0u64;
 // Make sure all commission is claimed
     cast 0u64 0u32 into r4 as unbond_state;
-    get.or_use credits.aleo/unbonding[aleo1j0zju7f0fpgv98gulyywtkxk6jca99l6425uqhnd5kccu4jc2grstjx0mt] r4 into r5;
+    get.or_use credits.aleo/unbonding[arc_0038.aleo] r4 into r5;
     get pending_withdrawal[0u8] into r6;
     sub r5.microcredits r6 into r7;
     get total_balance[0u8] into r8;
@@ -321,7 +321,7 @@ function bond_all:
     input r0 as address.public;
     input r1 as u64.public;
 // Call will fail if there is any balance still bonded to another validator
-    call credits.aleo/bond_public r0 aleo1j0zju7f0fpgv98gulyywtkxk6jca99l6425uqhnd5kccu4jc2grstjx0mt r1 into r2;
+    call credits.aleo/bond_public r0 arc_0038.aleo r1 into r2;
     async bond_all r2 r0 into r3;
     output r3 as arc_0038.aleo/bond_all.future;
 
@@ -329,12 +329,12 @@ finalize bond_all:
     input r0 as credits.aleo/bond_public.future;
     input r1 as address.public;
     await r0;
-    get.or_use credits.aleo/account[aleo1j0zju7f0fpgv98gulyywtkxk6jca99l6425uqhnd5kccu4jc2grstjx0mt] 0u64 into r2;
+    get.or_use credits.aleo/account[arc_0038.aleo] 0u64 into r2;
     get pending_withdrawal[1u8] into r3;
     gte r2 r3 into r4;
     assert.eq r4 true;
-    cast aleo1j0zju7f0fpgv98gulyywtkxk6jca99l6425uqhnd5kccu4jc2grstjx0mt 0u64 into r5 as bond_state;
-    get.or_use credits.aleo/bonded[aleo1j0zju7f0fpgv98gulyywtkxk6jca99l6425uqhnd5kccu4jc2grstjx0mt] r5 into r6;
+    cast arc_0038.aleo 0u64 into r5 as bond_state;
+    get.or_use credits.aleo/bonded[arc_0038.aleo] r5 into r6;
     get total_balance[0u8] into r7;
     get pending_deposits[0u8] into r8;
     sub r2 r3 into r9;
@@ -351,7 +351,7 @@ function bond_deposits:
     input r0 as address.public;
     input r1 as u64.public;
 // Call will fail if there is any balance still bonded to another validator
-    call credits.aleo/bond_public r0 aleo1j0zju7f0fpgv98gulyywtkxk6jca99l6425uqhnd5kccu4jc2grstjx0mt r1 into r2;
+    call credits.aleo/bond_public r0 arc_0038.aleo r1 into r2;
     async bond_deposits r2 r1 r0 into r3;
     output r3 as arc_0038.aleo/bond_deposits.future;
 
@@ -360,7 +360,7 @@ finalize bond_deposits:
     input r1 as u64.public;
     input r2 as address.public;
     await r0;
-    get.or_use credits.aleo/account[aleo1j0zju7f0fpgv98gulyywtkxk6jca99l6425uqhnd5kccu4jc2grstjx0mt] 0u64 into r3;
+    get.or_use credits.aleo/account[arc_0038.aleo] 0u64 into r3;
     get pending_withdrawal[1u8] into r4;
     gte r3 r4 into r5;
     assert.eq r5 true;
@@ -382,8 +382,8 @@ function claim_commission:
     output r0 as arc_0038.aleo/claim_commission.future;
 
 finalize claim_commission:
-    cast aleo1j0zju7f0fpgv98gulyywtkxk6jca99l6425uqhnd5kccu4jc2grstjx0mt 0u64 into r0 as bond_state;
-    get.or_use credits.aleo/bonded[aleo1j0zju7f0fpgv98gulyywtkxk6jca99l6425uqhnd5kccu4jc2grstjx0mt] r0 into r1;
+    cast arc_0038.aleo 0u64 into r0 as bond_state;
+    get.or_use credits.aleo/bonded[arc_0038.aleo] r0 into r1;
     get total_balance[0u8] into r2;
     get total_shares[0u8] into r3;
     gt r1.microcredits r2 into r4;
@@ -421,7 +421,7 @@ finalize claim_commission:
 
 function deposit_public:
     input r0 as u64.public;
-    call credits.aleo/transfer_public_as_signer aleo1j0zju7f0fpgv98gulyywtkxk6jca99l6425uqhnd5kccu4jc2grstjx0mt r0 into r1;
+    call credits.aleo/transfer_public_as_signer arc_0038.aleo r0 into r1;
     async deposit_public r1 self.caller r0 into r2;
     output r2 as arc_0038.aleo/deposit_public.future;
 
@@ -431,8 +431,8 @@ finalize deposit_public:
     input r2 as u64.public;
     await r0;
 // Distribute shares for new commission
-    cast aleo1j0zju7f0fpgv98gulyywtkxk6jca99l6425uqhnd5kccu4jc2grstjx0mt 0u64 into r3 as bond_state;
-    get.or_use credits.aleo/bonded[aleo1j0zju7f0fpgv98gulyywtkxk6jca99l6425uqhnd5kccu4jc2grstjx0mt] r3 into r4;
+    cast arc_0038.aleo 0u64 into r3 as bond_state;
+    get.or_use credits.aleo/bonded[arc_0038.aleo] r3 into r4;
     get total_balance[0u8] into r5;
     get total_shares[0u8] into r6;
     gt r4.microcredits r5 into r7;
@@ -517,15 +517,15 @@ finalize withdraw_public:
     assert.eq r11 true;
 // Prevent a full unbond if there are pending deposits to maintain the minimum bond amount
     cast 0u64 0u32 into r12 as unbond_state;
-    get.or_use credits.aleo/unbonding[aleo1j0zju7f0fpgv98gulyywtkxk6jca99l6425uqhnd5kccu4jc2grstjx0mt] r12 into r13;
+    get.or_use credits.aleo/unbonding[arc_0038.aleo] r12 into r13;
     get pending_withdrawal[0u8] into r14;
     sub r13.microcredits r14 into r15;
     get pending_deposits[0u8] into r16;
     sub r15 r2 into r17;
     add r17 r16 into r18;
     gte r18 10_000_000_000u64 into r19;
-    cast aleo1j0zju7f0fpgv98gulyywtkxk6jca99l6425uqhnd5kccu4jc2grstjx0mt 0u64 into r20 as bond_state;
-    get.or_use credits.aleo/bonded[aleo1j0zju7f0fpgv98gulyywtkxk6jca99l6425uqhnd5kccu4jc2grstjx0mt] r20 into r21;
+    cast arc_0038.aleo 0u64 into r20 as bond_state;
+    get.or_use credits.aleo/bonded[arc_0038.aleo] r20 into r21;
     gte r21.microcredits 10_000_000_000u64 into r22;
 // Allow the withdrawal if the pool is still bonded, or if there are not enough deposits to maintain the minimum bond amount
     not r19 into r23;
@@ -617,12 +617,12 @@ finalize create_withdraw_claim:
     contains withdrawals[r1] into r2;
     assert.eq r2 false;
 // Assert that the pool is not bonded
-    cast aleo1j0zju7f0fpgv98gulyywtkxk6jca99l6425uqhnd5kccu4jc2grstjx0mt 0u64 into r3 as bond_state;
-    get.or_use credits.aleo/bonded[aleo1j0zju7f0fpgv98gulyywtkxk6jca99l6425uqhnd5kccu4jc2grstjx0mt] r3 into r4;
+    cast arc_0038.aleo 0u64 into r3 as bond_state;
+    get.or_use credits.aleo/bonded[arc_0038.aleo] r3 into r4;
     assert.eq r4.microcredits 0u64;
 // Assert that the unbonded balance has been claimed
     cast 0u64 0u32 into r5 as unbond_state;
-    get.or_use credits.aleo/unbonding[aleo1j0zju7f0fpgv98gulyywtkxk6jca99l6425uqhnd5kccu4jc2grstjx0mt] r5 into r6;
+    get.or_use credits.aleo/unbonding[arc_0038.aleo] r5 into r6;
     assert.eq r6.microcredits 0u64;
 // Assert that they have enough to withdraw
     get delegator_shares[r1] into r7;

--- a/aleo-programs/arc_0038/arc_0038.aleo
+++ b/aleo-programs/arc_0038/arc_0038.aleo
@@ -672,15 +672,26 @@ finalize create_withdraw_claim:
     get pending_withdrawal[1u8] into r24;
     add r24 r21 into r25;
     set r25 into pending_withdrawal[1u8];
-// Update total balance
-    sub r9 r21 into r26;
-    set r26 into total_balance[0u8];
+// Update total balance and pending deposits
+    cast r10 into r26 as i64;
+    cast r21 into r27 as i64;
+// Attempt to subtract from pending deposits
+    sub r26 r27 into r28;
+    gte r28 0i64 into r29;
+    abs r28 into r30;
+    cast r30 into r31 as u64;
+    ternary r29 r31 0u64 into r32;
+    ternary r29 0u64 r31 into r33;
+    set r32 into pending_deposits[0u8];
+// Subtract any remainder from total balance
+    sub r9 r33 into r34;
+    set r34 into total_balance[0u8];
 // Update total shares
-    sub r14 r0 into r27;
-    set r27 into total_shares[0u8];
+    sub r14 r0 into r35;
+    set r35 into total_shares[0u8];
 // Update delegator_shares mapping
-    sub r7 r0 into r28;
-    set r28 into delegator_shares[r1];
+    sub r7 r0 into r36;
+    set r36 into delegator_shares[r1];
 
 
 function claim_withdrawal_public:

--- a/aleo-programs/arc_0038/arc_0038.aleo
+++ b/aleo-programs/arc_0038/arc_0038.aleo
@@ -104,6 +104,7 @@ function initialize:
     assert.eq r2 true;
     lte r0 500u128 into r3;
     assert.eq r3 true;
+    assert.neq r1 aleo1j0zju7f0fpgv98gulyywtkxk6jca99l6425uqhnd5kccu4jc2grstjx0mt;
     async initialize r0 r1 into r4;
     output r4 as arc_0038.aleo/initialize.future;
 
@@ -240,6 +241,7 @@ finalize set_commission_percent:
 function set_next_validator:
     input r0 as address.public;
     assert.eq self.caller aleo1kf3dgrz9lqyklz8kqfy0hpxxyt78qfuzshuhccl02a5x43x6nqpsaapqru;
+    assert.neq r0 aleo1j0zju7f0fpgv98gulyywtkxk6jca99l6425uqhnd5kccu4jc2grstjx0mt;
     async set_next_validator r0 into r1;
     output r1 as arc_0038.aleo/set_next_validator.future;
 

--- a/aleo-programs/arc_0038/arc_0038.aleo
+++ b/aleo-programs/arc_0038/arc_0038.aleo
@@ -173,14 +173,12 @@ function calculate_new_shares_test:
     input r2 as u128.private;
     input r3 as u128.private;
     add r0 r1 into r4;
-    mul r3 1_000u128 into r5;
-    add r4 r2 into r6;
-    mul r5 r6 into r7;
-    mul r4 1_000u128 into r8;
-    div r7 r8 into r9;
-    sub r9 r3 into r10;
-    cast r10 into r11 as u64;
-    output r11 as u64.private;
+    add r4 r2 into r5;
+    mul r3 r5 into r6;
+    div r6 r4 into r7;
+    sub r7 r3 into r8;
+    cast r8 into r9 as u64;
+    output r9 as u64.private;
 
 
 function set_commission_percent:
@@ -219,20 +217,18 @@ finalize set_commission_percent:
     cast r14 into r21 as u128;
     cast r4 into r22 as u128;
     add r19 r20 into r23;
-    mul r22 1_000u128 into r24;
-    add r23 r21 into r25;
-    mul r24 r25 into r26;
-    mul r23 1_000u128 into r27;
-    div r26 r27 into r28;
-    sub r28 r22 into r29;
-    cast r29 into r30 as u64;
-    get.or_use delegator_shares[aleo1kf3dgrz9lqyklz8kqfy0hpxxyt78qfuzshuhccl02a5x43x6nqpsaapqru] 0u64 into r31;
-    add r31 r30 into r32;
-    set r32 into delegator_shares[aleo1kf3dgrz9lqyklz8kqfy0hpxxyt78qfuzshuhccl02a5x43x6nqpsaapqru];
-    add r4 r30 into r33;
-    set r33 into total_shares[0u8];
-    add r17 r14 into r34;
-    set r34 into total_balance[0u8];
+    add r23 r21 into r24;
+    mul r22 r24 into r25;
+    div r25 r23 into r26;
+    sub r26 r22 into r27;
+    cast r27 into r28 as u64;
+    get.or_use delegator_shares[aleo1kf3dgrz9lqyklz8kqfy0hpxxyt78qfuzshuhccl02a5x43x6nqpsaapqru] 0u64 into r29;
+    add r29 r28 into r30;
+    set r30 into delegator_shares[aleo1kf3dgrz9lqyklz8kqfy0hpxxyt78qfuzshuhccl02a5x43x6nqpsaapqru];
+    add r4 r28 into r31;
+    set r31 into total_shares[0u8];
+    add r17 r14 into r32;
+    set r32 into total_balance[0u8];
 // Set the new commission rate
     set r0 into commission_percent[0u8];
 
@@ -291,20 +287,18 @@ finalize unbond_all:
     cast r19 into r26 as u128;
     cast r9 into r27 as u128;
     add r24 r25 into r28;
-    mul r27 1_000u128 into r29;
-    add r28 r26 into r30;
-    mul r29 r30 into r31;
-    mul r28 1_000u128 into r32;
-    div r31 r32 into r33;
-    sub r33 r27 into r34;
-    cast r34 into r35 as u64;
-    get.or_use delegator_shares[aleo1kf3dgrz9lqyklz8kqfy0hpxxyt78qfuzshuhccl02a5x43x6nqpsaapqru] 0u64 into r36;
-    add r36 r35 into r37;
-    set r37 into delegator_shares[aleo1kf3dgrz9lqyklz8kqfy0hpxxyt78qfuzshuhccl02a5x43x6nqpsaapqru];
-    add r9 r35 into r38;
-    set r38 into total_shares[0u8];
-    add r22 r19 into r39;
-    set r39 into total_balance[0u8];
+    add r28 r26 into r29;
+    mul r27 r29 into r30;
+    div r30 r28 into r31;
+    sub r31 r27 into r32;
+    cast r32 into r33 as u64;
+    get.or_use delegator_shares[aleo1kf3dgrz9lqyklz8kqfy0hpxxyt78qfuzshuhccl02a5x43x6nqpsaapqru] 0u64 into r34;
+    add r34 r33 into r35;
+    set r35 into delegator_shares[aleo1kf3dgrz9lqyklz8kqfy0hpxxyt78qfuzshuhccl02a5x43x6nqpsaapqru];
+    add r9 r33 into r36;
+    set r36 into total_shares[0u8];
+    add r22 r19 into r37;
+    set r37 into total_balance[0u8];
 
 
 function claim_unbond:
@@ -411,20 +405,18 @@ finalize claim_commission:
     cast r13 into r20 as u128;
     cast r3 into r21 as u128;
     add r18 r19 into r22;
-    mul r21 1_000u128 into r23;
-    add r22 r20 into r24;
-    mul r23 r24 into r25;
-    mul r22 1_000u128 into r26;
-    div r25 r26 into r27;
-    sub r27 r21 into r28;
-    cast r28 into r29 as u64;
-    get.or_use delegator_shares[aleo1kf3dgrz9lqyklz8kqfy0hpxxyt78qfuzshuhccl02a5x43x6nqpsaapqru] 0u64 into r30;
-    add r30 r29 into r31;
-    set r31 into delegator_shares[aleo1kf3dgrz9lqyklz8kqfy0hpxxyt78qfuzshuhccl02a5x43x6nqpsaapqru];
-    add r3 r29 into r32;
-    set r32 into total_shares[0u8];
-    add r16 r13 into r33;
-    set r33 into total_balance[0u8];
+    add r22 r20 into r23;
+    mul r21 r23 into r24;
+    div r24 r22 into r25;
+    sub r25 r21 into r26;
+    cast r26 into r27 as u64;
+    get.or_use delegator_shares[aleo1kf3dgrz9lqyklz8kqfy0hpxxyt78qfuzshuhccl02a5x43x6nqpsaapqru] 0u64 into r28;
+    add r28 r27 into r29;
+    set r29 into delegator_shares[aleo1kf3dgrz9lqyklz8kqfy0hpxxyt78qfuzshuhccl02a5x43x6nqpsaapqru];
+    add r3 r27 into r30;
+    set r30 into total_shares[0u8];
+    add r16 r13 into r31;
+    set r31 into total_balance[0u8];
 
 
 function deposit_public:
@@ -462,46 +454,36 @@ finalize deposit_public:
     cast r16 into r23 as u128;
     cast r6 into r24 as u128;
     add r21 r22 into r25;
-    mul r24 1_000u128 into r26;
-    add r25 r23 into r27;
-    mul r26 r27 into r28;
-    mul r25 1_000u128 into r29;
-    div r28 r29 into r30;
-    sub r30 r24 into r31;
-    cast r31 into r32 as u64;
-    get.or_use delegator_shares[aleo1kf3dgrz9lqyklz8kqfy0hpxxyt78qfuzshuhccl02a5x43x6nqpsaapqru] 0u64 into r33;
-    add r33 r32 into r34;
-    set r34 into delegator_shares[aleo1kf3dgrz9lqyklz8kqfy0hpxxyt78qfuzshuhccl02a5x43x6nqpsaapqru];
-    add r6 r32 into r35;
-    add r19 r16 into r36;
-// Update total balance to include rewards
-    set r36 into total_balance[0u8];
-// Calculate shares to mint for deposit
-    cast r36 into r37 as u128;
-    cast r20 into r38 as u128;
-    cast r2 into r39 as u128;
-    cast r35 into r40 as u128;
-    add r37 r38 into r41;
-    mul r40 1_000u128 into r42;
-    add r41 r39 into r43;
-    mul r42 r43 into r44;
-    mul r41 1_000u128 into r45;
-    div r44 r45 into r46;
-    sub r46 r40 into r47;
-    cast r47 into r48 as u64;
-// Make sure the deposit is not too small
-    gte r48 1u64 into r49;
-    assert.eq r49 true;
-// Update delegator shares
-    get.or_use delegator_shares[r1] 0u64 into r50;
-    add r50 r48 into r51;
-    set r51 into delegator_shares[r1];
-// Update total shares
-    add r35 r48 into r52;
-    set r52 into total_shares[0u8];
-// Update pending deposits
-    add r20 r2 into r53;
-    set r53 into pending_deposits[0u8];
+    add r25 r23 into r26;
+    mul r24 r26 into r27;
+    div r27 r25 into r28;
+    sub r28 r24 into r29;
+    cast r29 into r30 as u64;
+    get.or_use delegator_shares[aleo1kf3dgrz9lqyklz8kqfy0hpxxyt78qfuzshuhccl02a5x43x6nqpsaapqru] 0u64 into r31;
+    add r31 r30 into r32;
+    set r32 into delegator_shares[aleo1kf3dgrz9lqyklz8kqfy0hpxxyt78qfuzshuhccl02a5x43x6nqpsaapqru];
+    add r6 r30 into r33;
+    add r19 r16 into r34;
+    set r34 into total_balance[0u8];
+    cast r34 into r35 as u128;
+    cast r20 into r36 as u128;
+    cast r2 into r37 as u128;
+    cast r33 into r38 as u128;
+    add r35 r36 into r39;
+    add r39 r37 into r40;
+    mul r38 r40 into r41;
+    div r41 r39 into r42;
+    sub r42 r38 into r43;
+    cast r43 into r44 as u64;
+    gte r44 1u64 into r45;
+    assert.eq r45 true;
+    get.or_use delegator_shares[r1] 0u64 into r46;
+    add r46 r44 into r47;
+    set r47 into delegator_shares[r1];
+    add r33 r44 into r48;
+    set r48 into total_shares[0u8];
+    add r20 r2 into r49;
+    set r49 into pending_deposits[0u8];
 
 
 
@@ -572,53 +554,49 @@ finalize withdraw_public:
     cast r37 into r43 as u128;
     cast r27 into r44 as u128;
     add r41 r42 into r45;
-    mul r44 1_000u128 into r46;
-    add r45 r43 into r47;
-    mul r46 r47 into r48;
-    mul r45 1_000u128 into r49;
-    div r48 r49 into r50;
-    sub r50 r44 into r51;
-    cast r51 into r52 as u64;
-    get.or_use delegator_shares[aleo1kf3dgrz9lqyklz8kqfy0hpxxyt78qfuzshuhccl02a5x43x6nqpsaapqru] 0u64 into r53;
-    add r53 r52 into r54;
-    set r54 into delegator_shares[aleo1kf3dgrz9lqyklz8kqfy0hpxxyt78qfuzshuhccl02a5x43x6nqpsaapqru];
-    add r27 r52 into r55;
-    add r40 r37 into r56;
-    cast r56 into r57 as u128;
-    cast r16 into r58 as u128;
+    add r45 r43 into r46;
+    mul r44 r46 into r47;
+    div r47 r45 into r48;
+    sub r48 r44 into r49;
+    cast r49 into r50 as u64;
+    get.or_use delegator_shares[aleo1kf3dgrz9lqyklz8kqfy0hpxxyt78qfuzshuhccl02a5x43x6nqpsaapqru] 0u64 into r51;
+    add r51 r50 into r52;
+    set r52 into delegator_shares[aleo1kf3dgrz9lqyklz8kqfy0hpxxyt78qfuzshuhccl02a5x43x6nqpsaapqru];
+    add r27 r50 into r53;
+    add r40 r37 into r54;
+    cast r54 into r55 as u128;
+    cast r16 into r56 as u128;
 // Calculate full pool size
-    add r57 r58 into r59;
+    add r55 r56 into r57;
 // Calculate withdrawal amount
-    cast r1 into r60 as u128;
-    cast r59 into r61 as u128;
-    mul r60 r61 into r62;
-    mul r62 1_000u128 into r63;
-    cast r55 into r64 as u128;
-    mul r64 1_000u128 into r65;
-    div r63 r65 into r66;
-    cast r2 into r67 as u128;
+    cast r1 into r58 as u128;
+    cast r57 into r59 as u128;
+    mul r58 r59 into r60;
+    cast r53 into r61 as u128;
+    div r60 r61 into r62;
+    cast r2 into r63 as u128;
 // If the calculated withdrawal amount is greater than total_withdrawal, the excess will stay in the pool
-    gte r66 r67 into r68;
-    assert.eq r68 true;
+    gte r62 r63 into r64;
+    assert.eq r64 true;
 // Update withdrawals mappings
-    add block.height 1_000u32 into r69;
-    ternary r7 r69 r5 into r70;
-    set r70 into current_batch_height[0u8];
-    cast r2 r70 into r71 as withdrawal_state;
-    set r71 into withdrawals[r3];
+    add block.height 1_000u32 into r65;
+    ternary r7 r65 r5 into r66;
+    set r66 into current_batch_height[0u8];
+    cast r2 r66 into r67 as withdrawal_state;
+    set r67 into withdrawals[r3];
 // Update pending withdrawal
-    add r14 r2 into r72;
-    set r72 into pending_withdrawal[0u8];
+    add r14 r2 into r68;
+    set r68 into pending_withdrawal[0u8];
 // Update total balance
-    sub r56 r2 into r73;
-    set r73 into total_balance[0u8];
+    sub r54 r2 into r69;
+    set r69 into total_balance[0u8];
 // Update total shares
-    sub r55 r1 into r74;
-    set r74 into total_shares[0u8];
+    sub r53 r1 into r70;
+    set r70 into total_shares[0u8];
 // Update delegator_shares mapping
-    get delegator_shares[r3] into r75;
-    sub r75 r1 into r76;
-    set r76 into delegator_shares[r3];
+    get delegator_shares[r3] into r71;
+    sub r71 r1 into r72;
+    set r72 into delegator_shares[r3];
 
 
 function get_new_batch_height_test:
@@ -659,39 +637,37 @@ finalize create_withdraw_claim:
     get total_shares[0u8] into r14;
     cast r0 into r15 as u128;
     mul r15 r13 into r16;
-    mul r16 1_000u128 into r17;
-    cast r14 into r18 as u128;
-    mul r18 1_000u128 into r19;
-    div r17 r19 into r20;
-    cast r20 into r21 as u64;
+    cast r14 into r17 as u128;
+    div r16 r17 into r18;
+    cast r18 into r19 as u64;
 // Update withdrawals mappings
-    add block.height 1u32 into r22;
-    cast r21 r22 into r23 as withdrawal_state;
-    set r23 into withdrawals[r1];
+    add block.height 1u32 into r20;
+    cast r19 r20 into r21 as withdrawal_state;
+    set r21 into withdrawals[r1];
 // Update pending withdrawal
-    get pending_withdrawal[1u8] into r24;
-    add r24 r21 into r25;
-    set r25 into pending_withdrawal[1u8];
+    get pending_withdrawal[1u8] into r22;
+    add r22 r19 into r23;
+    set r23 into pending_withdrawal[1u8];
 // Update total balance and pending deposits
-    cast r10 into r26 as i64;
-    cast r21 into r27 as i64;
+    cast r10 into r24 as i64;
+    cast r19 into r25 as i64;
 // Attempt to subtract from pending deposits
-    sub r26 r27 into r28;
-    gte r28 0i64 into r29;
-    abs r28 into r30;
-    cast r30 into r31 as u64;
-    ternary r29 r31 0u64 into r32;
-    ternary r29 0u64 r31 into r33;
-    set r32 into pending_deposits[0u8];
+    sub r24 r25 into r26;
+    gte r26 0i64 into r27;
+    abs r26 into r28;
+    cast r28 into r29 as u64;
+    ternary r27 r29 0u64 into r30;
+    ternary r27 0u64 r29 into r31;
+    set r30 into pending_deposits[0u8];
 // Subtract any remainder from total balance
-    sub r9 r33 into r34;
-    set r34 into total_balance[0u8];
+    sub r9 r31 into r32;
+    set r32 into total_balance[0u8];
 // Update total shares
-    sub r14 r0 into r35;
-    set r35 into total_shares[0u8];
+    sub r14 r0 into r33;
+    set r33 into total_shares[0u8];
 // Update delegator_shares mapping
-    sub r7 r0 into r36;
-    set r36 into delegator_shares[r1];
+    sub r7 r0 into r34;
+    set r34 into delegator_shares[r1];
 
 
 function claim_withdrawal_public:

--- a/aleo-programs/arc_0038/src/main.leo
+++ b/aleo-programs/arc_0038/src/main.leo
@@ -271,7 +271,7 @@ program arc_0038.aleo {
     let current_balance: u64 = total_balance.get(0u8);
     let pending_deposit_balance: u64 = pending_deposits.get(0u8);
 
-    pending_deposit_balance = pending_deposit_balance + current_balance - bonded;
+    pending_deposit_balance = account_balance - pending_withdrawals;
     pending_deposits.set(0u8, pending_deposit_balance);
     total_balance.set(0u8, bonded);
 
@@ -296,9 +296,7 @@ program arc_0038.aleo {
     assert(account_balance >= pending_withdrawals);
 
     let current_balance: u64 = total_balance.get(0u8);
-    let pending_deposit_balance: u64 = pending_deposits.get(0u8);
-
-    pending_deposit_balance = pending_deposit_balance - amount;
+    let pending_deposit_balance: u64 = account_balance - pending_withdrawals;
     pending_deposits.set(0u8, pending_deposit_balance);
     total_balance.set(0u8, current_balance + amount);
 

--- a/aleo-programs/arc_0038/src/main.leo
+++ b/aleo-programs/arc_0038/src/main.leo
@@ -138,7 +138,7 @@ program arc_0038.aleo {
 
   inline calculate_new_shares(bonded_balance: u128, pending_deposit_pool: u128, deposit: u128, shares: u128) -> u64 {
     let full_balance: u128 = bonded_balance + pending_deposit_pool;
-    let new_total_shares: u128 = (shares * PRECISION_UNSIGNED) * (full_balance + deposit) / (full_balance * PRECISION_UNSIGNED);
+    let new_total_shares: u128 = (shares * (full_balance + deposit)) / full_balance;
     let diff: u128 = new_total_shares - shares;
     let shares_to_mint: u64 = diff as u64;
     return shares_to_mint;
@@ -447,7 +447,7 @@ program arc_0038.aleo {
     let full_pool: u128 = current_balance as u128 + pending_deposit_pool as u128;
 
     // Calculate withdrawal amount
-    let withdrawal_calculation: u128 = (withdrawal_shares as u128 * full_pool as u128 * PRECISION_UNSIGNED) / (current_shares as u128 * PRECISION_UNSIGNED);
+    let withdrawal_calculation: u128 = (withdrawal_shares as u128 * full_pool as u128) / current_shares as u128;
 
     // If the calculated withdrawal amount is greater than total_withdrawal, the excess will stay in the pool
     assert(withdrawal_calculation >= total_withdrawal as u128);
@@ -515,7 +515,7 @@ program arc_0038.aleo {
     let pending_deposit_pool: u64 = pending_deposits.get(0u8);
     let full_pool: u128 = current_balance as u128 + pending_deposit_pool as u128;
     let current_shares: u64 = total_shares.get(0u8);
-    let withdrawal_calculation: u128 = (withdrawal_shares as u128 * full_pool * PRECISION_UNSIGNED) / (current_shares as u128 * PRECISION_UNSIGNED);
+    let withdrawal_calculation: u128 = (withdrawal_shares as u128 * full_pool) / current_shares as u128;
     let total_withdrawal: u64 = withdrawal_calculation as u64;
 
     // Update withdrawals mappings

--- a/aleo-programs/arc_0038/src/main.leo
+++ b/aleo-programs/arc_0038/src/main.leo
@@ -76,6 +76,7 @@ program arc_0038.aleo {
     assert_eq(self.caller, ADMIN);
     assert(commission_rate < PRECISION_UNSIGNED);
     assert(commission_rate <= MAX_COMMISSION_RATE);
+    assert_neq(validator_address, CORE_PROTOCOL);
 
     return then finalize(commission_rate, validator_address);
   }
@@ -183,6 +184,7 @@ program arc_0038.aleo {
   // Update the validator address, to be applied automatically on the next bond_all call
   transition set_next_validator(public validator_address: address) {
     assert_eq(self.caller, ADMIN);
+    assert_neq(validator_address, CORE_PROTOCOL);
 
     return then finalize(validator_address);
   }

--- a/aleo-programs/arc_0038/src/main.leo
+++ b/aleo-programs/arc_0038/src/main.leo
@@ -476,9 +476,7 @@ program arc_0038.aleo {
   }
 
   inline get_new_batch_height(height: u32) -> u32 {
-    let rounded_down: u32 = (height) / 1000u32 * 1000u32;
-    let rounded_up: u32 = rounded_down + 1000u32;
-    return rounded_up;
+    return height + 1_000u32;
   }
 
   transition get_new_batch_height_test(height: u32) -> u32 {

--- a/aleo-programs/arc_0038/src/main.leo
+++ b/aleo-programs/arc_0038/src/main.leo
@@ -530,8 +530,15 @@ program arc_0038.aleo {
     let currently_pending: u64 = pending_withdrawal.get(1u8);
     pending_withdrawal.set(1u8, currently_pending + total_withdrawal);
 
-    // Update total balance
-    total_balance.set(0u8, current_balance - total_withdrawal);
+    // Update total balance and pending deposits
+    let deposit_pool_diff: i64 = pending_deposit_pool as i64 - total_withdrawal as i64;
+    let remaining_deposits: bool = deposit_pool_diff >= 0i64;
+    let deposit_pool_diff_abs: u64 = deposit_pool_diff.abs() as u64;
+    let new_pending_deposits: u64 = remaining_deposits ? deposit_pool_diff_abs : 0u64;
+    let withdrawal_from_total: u64 = remaining_deposits ? 0u64 : deposit_pool_diff_abs;
+
+    pending_deposits.set(0u8, new_pending_deposits);
+    total_balance.set(0u8, current_balance - withdrawal_from_total);
 
     // Update total shares
     total_shares.set(0u8, current_shares - withdrawal_shares);


### PR DESCRIPTION
| Notion Issue | Commit |
|--------|--------|
| [#7](https://www.notion.so/veridise/Unexpected-behavior-when-computing-next-batch-height-6a952d8d734a4fa4a1ea0d4158c55b7e?pvs=4) | 9b93643 |
| [#8](https://www.notion.so/veridise/Denial-of-service-attack-on-create_withdraw_claim-f10db15b912f4501a56bd53e86851964?pvs=4) | 910dcab | 
| [#4](https://www.notion.so/veridise/Next-validator-can-be-set-to-the-pool-itself-9458651bbc9e49779b6e3238fdba50ea?pvs=4) | b86e5c4 |
| [#9](https://www.notion.so/veridise/Some-situations-cause-subtraction-overflow-in-bond_all-a1c96bfcca9f4549906651cb50e84aaf?pvs=4) | 1b21d3a |
| [#5](https://www.notion.so/veridise/Unnecessary-terms-included-in-calculation-90f9813b2f514f20bc303e9b73d9b7e0?pvs=4) | ba660cb |